### PR TITLE
Added handleResponse to each endpoint slice

### DIFF
--- a/src/components/dashboard/index.test.tsx
+++ b/src/components/dashboard/index.test.tsx
@@ -114,7 +114,7 @@ describe("Dashboard tests", () => {
     useEffect.mock.calls[2][0]();
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenLastCalledWith({
-      type: "holdings.accounts.list/request",
+      type: "holdings.accounts.list/fetchPage",
       payload: {},
     });
   });

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -25,7 +25,7 @@ export const Dashboard: React.FC<Props> = () => {
 
   useEffect(() => {
     if (accountEndpoint?.isFilled && accountEndpoint.success) {
-      dispatch(actions.holdings.accounts.list.request({}));
+      dispatch(actions.holdings.accounts.list.fetchPage({}));
     }
   }, [dispatch, accountEndpoint]);
 

--- a/src/features/account/index.test.ts
+++ b/src/features/account/index.test.ts
@@ -1,64 +1,58 @@
-import { account, requireAccount, selectors } from "./index";
+import { account, requireAccount, selectors, accountSlice } from "./index";
 import { testSaga } from "redux-saga-test-plan";
 import { authRequest, selectors as apiSelectors } from "features/api";
 
 describe("account saga", () => {
   it("finishes successfully", () => {
     const saga = account;
+    const request = {};
     const response = {
       success: true,
     };
-    testSaga(saga)
+    testSaga(saga, { payload: request })
       .next()
       .call(authRequest, {
         path: "/accounts/account",
         method: "GET",
       })
       .next(response)
-      .put({
-        type: "account.account/finish",
-        payload: { response },
-      })
+      .call(accountSlice.handleResponse, { request, response })
       .next()
       .isDone();
   });
   it("finishes unsuccessfully", () => {
     const saga = account;
+    const request = {};
     const response = {
       success: false,
       status: 500,
     };
-    testSaga(saga)
+    testSaga(saga, { payload: request })
       .next()
       .call(authRequest, {
         path: "/accounts/account",
         method: "GET",
       })
       .next(response)
-      .put({
-        type: "account.account/finish",
-        payload: { response },
-      })
+      .call(accountSlice.handleResponse, { request, response })
       .next()
       .isDone();
   });
   it("finishes unsuccessfully 401", () => {
     const saga = account;
+    const request = {};
     const response = {
       success: false,
       status: 401,
     };
-    testSaga(saga)
+    testSaga(saga, { payload: request })
       .next()
       .call(authRequest, {
         path: "/accounts/account",
         method: "GET",
       })
       .next(response)
-      .put({
-        type: "account.account/finish",
-        payload: { response },
-      })
+      .call(accountSlice.handleResponse, { request, response })
       .next()
       .put({
         type: "api/setAuth",
@@ -120,7 +114,7 @@ describe("requireAccount saga", () => {
       .next(account)
       .put({
         type: "account.account/request",
-        payload: undefined,
+        payload: {},
       })
       .next()
       .isDone();

--- a/src/features/api/endpoint/index.ts
+++ b/src/features/api/endpoint/index.ts
@@ -1,1 +1,2 @@
 export * from "./endpoint";
+export * from "./paginated";

--- a/src/features/api/endpoint/paginated.test.ts
+++ b/src/features/api/endpoint/paginated.test.ts
@@ -19,22 +19,6 @@ describe("test createPaginatedEndpointSlice function", () => {
       },
     },
   };
-  describe("test fetchFirst", () => {
-    it("fetches the first page from empty", () => {
-      const state = testSlice.reducer(
-        emptyEndpoint,
-        testSlice.actions.fetchFirst(undefined)
-      );
-      expect(state).toEqual(loadingEndpoint);
-    });
-    it("fetches the first page from filled", () => {
-      const state = testSlice.reducer(
-        filledEndpoint,
-        testSlice.actions.fetchFirst(undefined)
-      );
-      expect(state).toEqual(loadingEndpoint);
-    });
-  });
   describe("test fetchPage", () => {
     it("fetches the first page from empty", () => {
       const state = testSlice.reducer(

--- a/src/features/holdings/endpoints.ts
+++ b/src/features/holdings/endpoints.ts
@@ -1,6 +1,9 @@
-import { createEndpointSlice } from "features/api/endpoint";
+import {
+  createPaginatedEndpointSlice,
+  PaginatedEndpointRequest,
+} from "features/api/endpoint";
 
-export type ListRequest = {};
+export type ListRequest = PaginatedEndpointRequest & {};
 
 type Holding = {
   id: string;
@@ -11,7 +14,7 @@ type Holding = {
 
 export const endpoints = {
   accounts: {
-    list: createEndpointSlice<ListRequest, Holding>({
+    list: createPaginatedEndpointSlice<ListRequest, Holding>({
       name: "holdings.accounts.list",
     }),
   },

--- a/src/features/holdings/sagas.ts
+++ b/src/features/holdings/sagas.ts
@@ -1,16 +1,21 @@
 import { endpoints } from "./endpoints";
-import { call, takeEvery, put } from "redux-saga/effects";
+import { call, takeEvery } from "redux-saga/effects";
 import { authRequest } from "features/api";
+import {
+  paginatedSearchParams,
+  PaginatedEndpointAction,
+} from "features/api/endpoint";
 import { APIResponse } from "features/api/request";
 
-export function* list() {
+export function* accountsPage({ payload: request }: PaginatedEndpointAction) {
+  const searchParams = paginatedSearchParams(request);
   const response: APIResponse = yield call(authRequest, {
-    path: "/holding_accounts",
+    path: `/holding_accounts?${searchParams.toString()}`,
     method: "GET",
   });
-  yield put(endpoints.accounts.list.actions.finish({ response }));
+  yield call(endpoints.accounts.list.handleResponse, { request, response });
 }
 
 export function* sagas() {
-  yield takeEvery("holdings.accounts.list/request", list);
+  yield takeEvery("holdings.accounts.list/fetchPage", accountsPage);
 }


### PR DESCRIPTION
- This handleResponse callback is meant to be used in the sagas for requesting each of these endpoints in order to issue the expected saga effects.
- In addition, I added a "callback" field by default so that the caller of each action can determine what happens after the request completes. In this way, I can do things like fetch additional pages.