### PR TITLE
Added support for fetching all pages of an API endpoint

### DIFF
--- a/src/components/dashboard/index.test.tsx
+++ b/src/components/dashboard/index.test.tsx
@@ -108,7 +108,7 @@ describe("Dashboard tests", () => {
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenLastCalledWith({
       type: "holdings.accounts.list/fetchPage",
-      payload: {},
+      payload: { fetchAll: true },
     });
   });
 });

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -25,7 +25,7 @@ export const Dashboard: React.FC<Props> = () => {
 
   useEffect(() => {
     if (accountEndpoint?.isFilled && accountEndpoint.success) {
-      dispatch(actions.holdings.accounts.list.fetchPage({}));
+      dispatch(actions.holdings.accounts.list.fetchAllPages({}));
     }
   }, [dispatch, accountEndpoint]);
 

--- a/src/features/api/endpoint/paginated.test.ts
+++ b/src/features/api/endpoint/paginated.test.ts
@@ -131,15 +131,41 @@ describe("test createPaginatedEndpointSlice function", () => {
     });
   });
   describe("test handleResponse", () => {
-    it("runs handleResponse without a callback", () => {
+    it("runs handleResponse", () => {
       const request = {};
-      const response = {};
+      const response = {
+        success: true,
+        data: { next: "next-url" },
+      };
       const saga = testSlice.handleResponse;
       testSaga(saga, { request, response })
         .next()
         .put({
           type: "test-slice/finishPage",
           payload: { request, response },
+        })
+        .next()
+        .isDone();
+    });
+    it("runs handleResponse fetches next page", () => {
+      const request = {
+        fetchAll: true,
+      };
+      const response = {
+        success: true,
+        data: { next: "next-url" },
+      };
+      const saga = testSlice.handleResponse;
+      testSaga(saga, { request, response })
+        .next()
+        .put({
+          type: "test-slice/finishPage",
+          payload: { request, response },
+        })
+        .next()
+        .put({
+          type: "test-slice/fetchPage",
+          payload: { ...request, url: "next-url" },
         })
         .next()
         .isDone();
@@ -160,6 +186,19 @@ describe("test createPaginatedEndpointSlice function", () => {
         .call(request.callback, response)
         .next()
         .isDone();
+    });
+  });
+  describe("test fetchAllPages", () => {
+    it("runs fetchAllPages and callback with next", () => {
+      const request = { key: "value" };
+      const action = testSlice.actions.fetchAllPages(request);
+      expect(action).toEqual({
+        payload: {
+          key: "value",
+          fetchAll: true,
+        },
+        type: "test-slice/fetchPage",
+      });
     });
   });
 });

--- a/src/features/api/endpoint/paginated.ts
+++ b/src/features/api/endpoint/paginated.ts
@@ -14,18 +14,25 @@ import {
   EndpointProps,
   EndpointRequest,
 } from "./endpoint";
-import { DefaultError } from "../request";
+import { DefaultError, APIResponse } from "../request";
 import { call, put } from "redux-saga/effects";
 
 export type PaginatedEndpointRequest = EndpointRequest & {
+  url?: string;
   page?: number;
+  fetchAll: boolean;
 };
 
 export type PaginatedEndpointAction<
   R extends PaginatedEndpointRequest = PaginatedEndpointRequest,
 > = PayloadAction<R>;
 
-export function paginatedSearchParams({ page }: PaginatedEndpointRequest) {
+export function paginatedSearchParams({ url, page }: PaginatedEndpointRequest) {
+  if (url) {
+    const parsedURL = new URL(url);
+    return parsedURL.searchParams;
+  }
+
   return new URLSearchParams({ page: `${page ?? 1}` });
 }
 
@@ -127,9 +134,22 @@ export function createPaginatedEndpointSlice<
     },
   });
 
-  const { reducer, actions } = slice;
   function* handleResponse({ request, response }: EndpointResponse<R>) {
-    yield put(actions.finishPage({ request, response }));
+    yield put(slice.actions.finishPage({ request, response }));
+
+    const { fetchAll } = request;
+    const { success, data } = response;
+    if (fetchAll && success && data) {
+      const { next } = data as PaginatedEndpointResponse;
+      if (next) {
+        yield put(
+          slice.actions.fetchPage({
+            ...request,
+            url: next,
+          }),
+        );
+      }
+    }
 
     const { callback } = request;
     if (callback) {
@@ -137,5 +157,20 @@ export function createPaginatedEndpointSlice<
     }
   }
 
-  return { reducer, actions, handleResponse };
+  function fetchAllPages(request: R) {
+    return slice.actions.fetchPage({
+      ...request,
+      fetchAll: true,
+    });
+  }
+
+  const { actions } = slice;
+  return {
+    ...slice,
+    handleResponse,
+    actions: {
+      ...actions,
+      fetchAllPages,
+    },
+  };
 }


### PR DESCRIPTION
- This change adds support for fetching all pages of an API endpoint. In order to accomplish this, I've added the "url" and "fetchAll" field to the "PaginatedEndpointRequest" type. I've also added a "fetchAllPages" function to paginated slices.
- In order to accomplish the fetching of all pages, I've also extended the "handleResponse" callback for the paginated slices to handle this field when we get each API response.