### PR TITLE
Rework the router to allow for subroutes

### DIFF
--- a/src/components/account/AuthGate.test.tsx
+++ b/src/components/account/AuthGate.test.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect } from "react";
+import { vi, describe, beforeEach, it, expect } from "vitest";
+import { useDispatch, useSelector } from "react-redux";
+import { shallow } from "enzyme";
+import { useNavigate } from "react-router";
+
+import { AuthGate } from "./AuthGate";
+
+vi.mock("react", () => {
+  return {
+    useEffect: vi.fn(),
+  };
+});
+
+vi.mock("react-redux", () => {
+  return {
+    useDispatch: vi.fn(),
+    useSelector: vi.fn(),
+  };
+});
+
+vi.mock("react-router", () => {
+  return {
+    useNavigate: vi.fn(),
+  };
+});
+
+function mockSelector({ hasAuth }) {
+  let iteration = -1;
+  useSelector.mockImplementation(() => {
+    iteration = (iteration + 1) % 1;
+    switch (iteration) {
+      case 0:
+        return hasAuth;
+    }
+  });
+}
+
+describe("AuthGate tests", () => {
+  let props = null;
+  let dispatch = null;
+  let navigate = null;
+  beforeEach(() => {
+    props = {};
+    dispatch = vi.fn();
+    useEffect.mockReset();
+    useDispatch.mockReset();
+    useDispatch.mockReturnValue(dispatch);
+    useSelector.mockReset();
+    navigate = vi.fn();
+    useNavigate.mockReset();
+    useNavigate.mockReturnValue(navigate);
+  });
+  it("redirects to /login when there is no auth present", () => {
+    const component = shallow(<AuthGate {...props}>children</AuthGate>);
+    expect(component.text()).toEqual("");
+
+    const cleanup = useEffect.mock.calls[0][0]();
+    expect(cleanup).toEqual(undefined);
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenLastCalledWith("/login");
+  });
+  it("renders children if there is auth present", () => {
+    mockSelector({ hasAuth: true });
+    const component = shallow(<AuthGate {...props}>children</AuthGate>);
+    expect(component.text()).toEqual("children");
+
+    const cleanup = useEffect.mock.calls[0][0]();
+    expect(cleanup).toEqual(undefined);
+    expect(navigate).toHaveBeenCalledTimes(0);
+  });
+  it("redirects to configured route if specified", () => {
+    mockSelector({ hasAuth: true });
+    const component = shallow(
+      <AuthGate {...props} redirectHasAuth="/route">
+        children
+      </AuthGate>,
+    );
+    expect(component.text()).toEqual("");
+
+    const cleanup = useEffect.mock.calls[0][0]();
+    expect(cleanup).toEqual(undefined);
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenLastCalledWith("/route");
+  });
+});

--- a/src/components/account/AuthGate.tsx
+++ b/src/components/account/AuthGate.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, ReactNode } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { selectors } from "features";
+import { useNavigate } from "react-router";
+
+export type Props = {
+  redirectHasAuth?: boolean;
+  children?: ReactNode | ReactNode[];
+};
+
+export const AuthGate: React.FC<Props> = ({
+  redirectHasAuth,
+  children,
+}: Props) => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const hasAuth = useSelector(selectors.api.hasAuth);
+
+  useEffect(() => {
+    if (!hasAuth) {
+      navigate("/login");
+      return;
+    }
+
+    if (redirectHasAuth) {
+      navigate(redirectHasAuth);
+    }
+  }, [redirectHasAuth, hasAuth, navigate]);
+
+  // If we're expecting the "useEffect" above to redirect, don't render
+  // anything.
+  if (!hasAuth || redirectHasAuth) {
+    return null;
+  }
+
+  return children;
+};

--- a/src/components/account/AuthGate.tsx
+++ b/src/components/account/AuthGate.tsx
@@ -4,7 +4,7 @@ import { selectors } from "features";
 import { useNavigate } from "react-router";
 
 export type Props = {
-  redirectHasAuth?: boolean;
+  redirectHasAuth?: string;
   children?: ReactNode | ReactNode[];
 };
 

--- a/src/components/account/LoggedInApp.test.tsx
+++ b/src/components/account/LoggedInApp.test.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect } from "react";
+import { vi, describe, beforeEach, it, expect } from "vitest";
+import { useDispatch, useSelector } from "react-redux";
+import { shallow } from "enzyme";
+import { emptyEndpoint } from "features/api/endpoint";
+
+import { LoggedInApp } from "./LoggedInApp";
+
+vi.mock("react", () => {
+  return {
+    useEffect: vi.fn(),
+  };
+});
+
+vi.mock("react-redux", () => {
+  return {
+    useDispatch: vi.fn(),
+    useSelector: vi.fn(),
+  };
+});
+
+function mockSelector({ accountEndpoint }) {
+  let iteration = -1;
+  useSelector.mockImplementation(() => {
+    iteration = (iteration + 1) % 1;
+    switch (iteration) {
+      case 0:
+        return accountEndpoint ?? emptyEndpoint;
+    }
+  });
+}
+
+describe("LoggedInApp tests", () => {
+  let props = null;
+  let dispatch = null;
+  beforeEach(() => {
+    props = {};
+    dispatch = vi.fn();
+    useEffect.mockReset();
+    useDispatch.mockReset();
+    useDispatch.mockReturnValue(dispatch);
+    useSelector.mockReset();
+  });
+  it("kicks off requireAccount on load", () => {
+    mockSelector({});
+    const component = shallow(<LoggedInApp {...props} />);
+    expect(component.text()).toEqual("");
+
+    const cleanup = useEffect.mock.calls[0][0]();
+    expect(cleanup).toEqual(undefined);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenLastCalledWith({
+      type: "account.requireAccount",
+    });
+  });
+  it("renders Outlet if account is filled", () => {
+    const accountEndpoint = { isFilled: true };
+    mockSelector({ accountEndpoint });
+    const component = shallow(<LoggedInApp {...props} />);
+    expect(component.text()).not.toEqual("");
+    expect(component.find("Outlet")).toHaveLength(1);
+  });
+});

--- a/src/components/account/LoggedInApp.tsx
+++ b/src/components/account/LoggedInApp.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { actions, selectors } from "features";
+import { Outlet } from "react-router-dom";
+
+export type Props = {};
+
+export const LoggedInApp: React.FC<Props> = () => {
+  const dispatch = useDispatch();
+
+  const accountEndpoint = useSelector(selectors.account.account);
+
+  useEffect(() => {
+    dispatch(actions.account.requireAccount());
+  }, [dispatch]);
+
+  if (!accountEndpoint.isFilled) {
+    return null;
+  }
+
+  return <Outlet />;
+};

--- a/src/components/account/index.tsx
+++ b/src/components/account/index.tsx
@@ -1,0 +1,3 @@
+export { Login } from "./Login";
+export { LoggedInApp } from "./LoggedInApp";
+export { AuthGate } from "./AuthGate";

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -36,5 +36,3 @@ export const Dashboard: React.FC<Props> = () => {
 
   return <div>Dashboard!</div>;
 };
-
-export default Dashboard;

--- a/src/components/root/Top.tsx
+++ b/src/components/root/Top.tsx
@@ -39,5 +39,3 @@ export const Top: React.FC<Props> = () => {
     </Box>
   );
 };
-
-export default Top;

--- a/src/components/root/router.tsx
+++ b/src/components/root/router.tsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter } from "react-router-dom";
-import Top from "./Top";
-import Dashboard from "components/dashboard";
-import Login from "components/account/Login";
+import { Top } from "./Top";
+import { Dashboard } from "components/dashboard";
+import { Login, LoggedInApp, AuthGate } from "components/account";
 
 export const router = createBrowserRouter([
   {
@@ -10,7 +10,21 @@ export const router = createBrowserRouter([
     children: [
       {
         index: true,
-        element: <Dashboard />,
+        element: <AuthGate redirectHasAuth="/app" />,
+      },
+      {
+        path: "app",
+        element: (
+          <AuthGate>
+            <LoggedInApp />
+          </AuthGate>
+        ),
+        children: [
+          {
+            index: true,
+            element: <Dashboard />,
+          },
+        ],
       },
       {
         path: "login",

--- a/src/features/api/endpoint/endpoint.ts
+++ b/src/features/api/endpoint/endpoint.ts
@@ -114,7 +114,7 @@ export function createEndpointSlice<
   function* handleResponse({ request, response }: EndpointResponse<R>) {
     yield put(actions.finish({ request, response }));
 
-    const { callback } = request;
+    const callback = request?.callback;
     if (callback) {
       yield call(callback, response);
     }


### PR DESCRIPTION
- I added the "AuthGate" as a common component in order to gate the rendering of children or redirecting based on whether or not we have authentication materials in our redux store.
- This component will route the top-level route as well as the new LoggedInApp component, which ensures that the API can be used before rendering its Outlet.